### PR TITLE
ci: build multi-arch images (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@165fe681b849eec43aaa64d786b9ec53e690475f
 
@@ -59,6 +62,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Closes #4. Same change as neuroforgede/docker-engine-networks-exporter#6.

## What

Add `docker/setup-qemu-action` (so the amd64 GitHub runner can emulate arm64) and pass `platforms: linux/amd64,linux/arm64` to `docker/build-push-action`. Three lines, one file.

No `Dockerfile` change needed — `python:3.10-alpine` is already a multi-arch manifest list, and the install step is just `pip install`, no native bits.

## Validation

I ran the modified workflow in my fork and the resulting image is multi-arch:

- Fork CI run (green, 1m17s): https://github.com/francescor/docker-engine-events-exporter/actions/runs/27405413266
- Resulting image: `ghcr.io/francescor/docker-engine-events-exporter:master` — `docker manifest inspect` shows both `linux/amd64` and `linux/arm64`.